### PR TITLE
Replace deprecated calls.

### DIFF
--- a/nested_inline/admin.py
+++ b/nested_inline/admin.py
@@ -76,10 +76,10 @@ class NestedModelAdmin(admin.ModelAdmin):
                 if request.method == 'POST' and any(s.startswith(prefix) for s in request.POST.keys()):
                     nested_formset = InlineFormSet(request.POST, request.FILES,
                         instance=form.instance,
-                        prefix=prefix, queryset=nested_inline.queryset(request))
+                        prefix=prefix, queryset=nested_inline.get_queryset(request))
                 else:
                     nested_formset = InlineFormSet(instance=form.instance,
-                        prefix=prefix, queryset=nested_inline.queryset(request))
+                        prefix=prefix, queryset=nested_inline.get_queryset(request))
                 nested_formsets.append(nested_formset)
                 if nested_inline.inlines:
                     self.add_nested_inline_formsets(request, nested_inline, nested_formset, depth=depth+1)
@@ -173,7 +173,7 @@ class NestedModelAdmin(admin.ModelAdmin):
                 formset = FormSet(data=request.POST, files=request.FILES,
                     instance=new_object,
                     save_as_new="_saveasnew" in request.POST,
-                    prefix=prefix, queryset=inline.queryset(request))
+                    prefix=prefix, queryset=inline.get_queryset(request))
                 formsets.append(formset)
                 if inline.inlines:
                     self.add_nested_inline_formsets(request, inline, formset)
@@ -201,7 +201,7 @@ class NestedModelAdmin(admin.ModelAdmin):
                 if prefixes[prefix] != 1 or not prefix:
                     prefix = "%s-%s" % (prefix, prefixes[prefix])
                 formset = FormSet(instance=self.model(), prefix=prefix,
-                    queryset=inline.queryset(request))
+                    queryset=inline.get_queryset(request))
                 formsets.append(formset)
                 if hasattr(inline, 'inlines') and inline.inlines:
                     self.add_nested_inline_formsets(request, inline, formset)
@@ -276,7 +276,7 @@ class NestedModelAdmin(admin.ModelAdmin):
                     prefix = "%s-%s" % (prefix, prefixes[prefix])
                 formset = FormSet(request.POST, request.FILES,
                     instance=new_object, prefix=prefix,
-                    queryset=inline.queryset(request))
+                    queryset=inline.get_queryset(request))
                 formsets.append(formset)
                 if hasattr(inline, 'inlines') and inline.inlines:
                     self.add_nested_inline_formsets(request, inline, formset)
@@ -297,7 +297,7 @@ class NestedModelAdmin(admin.ModelAdmin):
                 if prefixes[prefix] != 1 or not prefix:
                     prefix = "%s-%s" % (prefix, prefixes[prefix])
                 formset = FormSet(instance=obj, prefix=prefix,
-                    queryset=inline.queryset(request))
+                    queryset=inline.get_queryset(request))
                 formsets.append(formset)
                 if hasattr(inline, 'inlines') and inline.inlines:
                     self.add_nested_inline_formsets(request, inline, formset)

--- a/nested_inline/admin.py
+++ b/nested_inline/admin.py
@@ -144,7 +144,7 @@ class NestedModelAdmin(admin.ModelAdmin):
         return True
 
     @csrf_protect_m
-    @transaction.commit_on_success
+    @transaction.atomic
     def add_view(self, request, form_url='', extra_context=None):
         "The 'add' admin view for this model."
         model = self.model
@@ -238,7 +238,7 @@ class NestedModelAdmin(admin.ModelAdmin):
         return self.render_change_form(request, context, form_url=form_url, add=True)
 
     @csrf_protect_m
-    @transaction.commit_on_success
+    @transaction.atomic
     def change_view(self, request, object_id, form_url='', extra_context=None):
         "The 'change' admin view for this model."
         model = self.model

--- a/nested_inline/templates/admin/edit_inline/tabular-nested.html
+++ b/nested_inline/templates/admin/edit_inline/tabular-nested.html
@@ -1,4 +1,5 @@
 {% load i18n admin_static admin_modify %}
+{% load cycle from future %}
 <div class="inline-group{% if recursive_formset %} {{ recursive_formset.formset.prefix|default:"Root" }}-nested-inline{% if prev_prefix %} {{ prev_prefix }}-{{ loopCounter }}-nested-inline{% endif %} nested-inline{% endif %}" id="{{ inline_admin_formset.formset.prefix }}-group">
 {% with recursive_formset=inline_admin_formset stacked_template='admin/edit_inline/stacked-nested.html' tabular_template='admin/edit_inline/tabular-nested.html'%}
   <div class="tabular inline-related {% if forloop.last %}last-related{% endif %}" id="{{ recursive_formset.formset.prefix }}">


### PR DESCRIPTION
I triggered several RemovedInDjango18Warning messages when using Django 1.7. This replaces the deprecated calls with new versions.

Note that this will *not* work with Django 1.4 LTS. 1.6 should be fine but is not tested.