### PR TITLE
Fixing Deprecation Warning for Django 1.8

### DIFF
--- a/nested_inline/admin.py
+++ b/nested_inline/admin.py
@@ -76,10 +76,10 @@ class NestedModelAdmin(admin.ModelAdmin):
                 if request.method == 'POST' and any(s.startswith(prefix) for s in request.POST.keys()):
                     nested_formset = InlineFormSet(request.POST, request.FILES,
                         instance=form.instance,
-                        prefix=prefix, queryset=nested_inline.queryset(request))
+                        prefix=prefix, queryset=nested_inline.get_queryset(request))
                 else:
                     nested_formset = InlineFormSet(instance=form.instance,
-                        prefix=prefix, queryset=nested_inline.queryset(request))
+                        prefix=prefix, queryset=nested_inline.get_queryset(request))
                 nested_formsets.append(nested_formset)
                 if nested_inline.inlines:
                     self.add_nested_inline_formsets(request, nested_inline, nested_formset, depth=depth+1)
@@ -173,7 +173,7 @@ class NestedModelAdmin(admin.ModelAdmin):
                 formset = FormSet(data=request.POST, files=request.FILES,
                     instance=new_object,
                     save_as_new="_saveasnew" in request.POST,
-                    prefix=prefix, queryset=inline.queryset(request))
+                    prefix=prefix, queryset=inline.get_queryset(request))
                 formsets.append(formset)
                 if inline.inlines:
                     self.add_nested_inline_formsets(request, inline, formset)
@@ -201,7 +201,7 @@ class NestedModelAdmin(admin.ModelAdmin):
                 if prefixes[prefix] != 1 or not prefix:
                     prefix = "%s-%s" % (prefix, prefixes[prefix])
                 formset = FormSet(instance=self.model(), prefix=prefix,
-                    queryset=inline.queryset(request))
+                    queryset=inline.get_queryset(request))
                 formsets.append(formset)
                 if hasattr(inline, 'inlines') and inline.inlines:
                     self.add_nested_inline_formsets(request, inline, formset)
@@ -276,7 +276,7 @@ class NestedModelAdmin(admin.ModelAdmin):
                     prefix = "%s-%s" % (prefix, prefixes[prefix])
                 formset = FormSet(request.POST, request.FILES,
                     instance=new_object, prefix=prefix,
-                    queryset=inline.queryset(request))
+                    queryset=inline.get_queryset(request))
                 formsets.append(formset)
                 if hasattr(inline, 'inlines') and inline.inlines:
                     self.add_nested_inline_formsets(request, inline, formset)
@@ -297,7 +297,7 @@ class NestedModelAdmin(admin.ModelAdmin):
                 if prefixes[prefix] != 1 or not prefix:
                     prefix = "%s-%s" % (prefix, prefixes[prefix])
                 formset = FormSet(instance=obj, prefix=prefix,
-                    queryset=inline.queryset(request))
+                    queryset=inline.get_queryset(request))
                 formsets.append(formset)
                 if hasattr(inline, 'inlines') and inline.inlines:
                     self.add_nested_inline_formsets(request, inline, formset)


### PR DESCRIPTION
RemovedInDjango18Warning, replaced queryset by get_queryset