### PR TITLE
fixing RemovedInDjango19Warning

### DIFF
--- a/nested_inline/admin.py
+++ b/nested_inline/admin.py
@@ -8,7 +8,7 @@ from django.utils.decorators import method_decorator
 from django.utils.encoding import force_text
 from django.views.decorators.csrf import csrf_protect
 from django.utils.translation import ugettext as _
-from django.contrib.admin.util import unquote
+from django.contrib.admin.utils import unquote
 from django.db import transaction, models
 from django.utils.html import escape
 from django.conf import settings


### PR DESCRIPTION
Django 1.9 will remove `django.contrib.admin.util` in favor of `django.contrib.admin.utils` ([source](https://docs.djangoproject.com/fr/1.8/internals/deprecation/#deprecation-removed-in-1-9)). On Django 1.8, we currently get a warning, but it'll become an error in 1.9.