### PR TITLE
remove value attr when template cloned

### DIFF
--- a/nested_inline/static/admin/js/inlines-nested.js
+++ b/nested_inline/static/admin/js/inlines-nested.js
@@ -58,6 +58,7 @@
                 var nextIndex = get_no_forms(options.prefix);
                 var template = $("#" + options.prefix + "-empty");
                 var row = template.clone(true);
+                row.find('input:hidden').removeAttr('value');
                 row.removeClass(options.emptyCssClass).addClass(options.formCssClass).attr("id", options.prefix + "-" + nextIndex);
                 if (row.is("tr")) {
                     // If the forms are laid out in table rows, insert


### PR DESCRIPTION
if i add more than 2 items on change form and try to save, changes are not saved because add item has been cloned from previous item and had it's parent object's id on reference field.

so delete hidden input field's value attribute to fix above problem