### PR TITLE
fix for Django 1.10 compatibility

### DIFF
--- a/nested_inline/templates/admin/edit_inline/tabular-nested.html
+++ b/nested_inline/templates/admin/edit_inline/tabular-nested.html
@@ -1,5 +1,4 @@
 {% load i18n admin_static admin_modify %}
-{% load cycle from future %}
 <div class="inline-group{% if recursive_formset %} {{ recursive_formset.formset.prefix|default:"Root" }}-nested-inline{% if prev_prefix %} {{ prev_prefix }}-{{ loopCounter }}-nested-inline{% endif %} nested-inline{% endif %}" id="{{ inline_admin_formset.formset.prefix }}-group">
 {% with recursive_formset=inline_admin_formset stacked_template='admin/edit_inline/stacked-nested.html' tabular_template='admin/edit_inline/tabular-nested.html'%}
   <div class="tabular inline-related {% if forloop.last %}last-related{% endif %}" id="{{ recursive_formset.formset.prefix }}">


### PR DESCRIPTION
fix for Django 1.10: remove cycle from future template tag loading in tabular-nested.html
This fixes #65 
