### PR TITLE
Added a super call for admin.NestedModelAdmin.get_inline_instances

### DIFF
--- a/nested_inline/admin.py
+++ b/nested_inline/admin.py
@@ -28,7 +28,8 @@ class NestedModelAdmin(admin.ModelAdmin):
         js = ('admin/js/inlines-nested.js',)
 
     def get_inline_instances(self, request, obj=None):
-        inline_instances = []
+        inline_instances = super(
+            NestedModelAdmin, self).get_inline_instances(request, obj)
         for inline_class in self.inlines:
             inline = inline_class(self.model, self.admin_site)
             if request:


### PR DESCRIPTION
Maybe a noob problem, but I got an empty list when doing:
```
class ExampleAdmin(NestedModelAdmin, SpecificAdmin1, SpecificAdmin2):
    def get_inline_instances(self, request, obj=None):
        inlines_inst = super(
            ExampleAdmin, self).get_inline_instances(request, obj)
```
Instead of getting an Inline from SpecificAdmin2...

With this patch, the MRO resolution of get_inline_instances is different and I finally get my Inline from SpecificAdmin2!

Is is something desirable for all cases?
