### PR TITLE
Update media so it expects to find jquery in the right place.

### DIFF
--- a/nested_inline/admin.py
+++ b/nested_inline/admin.py
@@ -354,7 +354,11 @@ class NestedInline(InlineModelAdmin):
     @property
     def media(self):
         extra = '' if settings.DEBUG else '.min'
-        js = ['jquery%s.js' % extra, 'jquery.init.js', 'inlines-nested%s.js' % extra]
+        if VERSION[:2] >= (1, 9):
+            js = ['vendor/jquery/jquery%s.js' % extra, 'jquery.init.js']
+        else:
+            js = ['jquery%s.js' % extra, 'jquery.init.js']
+        js.append('inlines-nested%s.js' % extra)
         if self.prepopulated_fields:
             js.extend(['urlify.js', 'prepopulate%s.js' % extra])
         if self.filter_vertical or self.filter_horizontal:


### PR DESCRIPTION
@s-block This PR updates `NestedInline.media()` so that it accords with the placement of jquery in a `vendor` directory in django 1.9+.

## Testing

I tested an admin page using a `NestedInline` with and without this change. 

### With this change
Everything is fine. No network errors or 404s.
<img width="843" alt="screen shot 2017-01-12 at 8 51 50 pm" src="https://cloud.githubusercontent.com/assets/123110/21918751/8c26686a-d909-11e6-8811-4572912330cc.png">

### Without this change
The browser attempts to download jquery, but can't find it.
<img width="843" alt="screen shot 2017-01-12 at 8 49 29 pm" src="https://cloud.githubusercontent.com/assets/123110/21918755/9270e132-d909-11e6-9c9c-7c0f78b6faff.png">

<hr>

**Thanks for writing this library!** We've found it very useful.