### PR TITLE
Repair "The inline foreign key did not match the parent instance primary key"

### DIFF
--- a/nested_inline/static/admin/js/inlines-nested.js
+++ b/nested_inline/static/admin/js/inlines-nested.js
@@ -305,17 +305,17 @@
                 template.find(".nested-inline-row").remove();
                 // Make a new form
                 template_form = template.find("#" + normalized_formset_prefix + "-empty")
-                new_form = template_form.clone().removeClass(options.emptyCssClass).addClass("dynamic-" + formset_prefix);
-
-                new_form.insertBefore(template_form);
-
-                var inputs = new_form.find('input');
+                
+                var inputs = template_form.find('input');
                 inputs.each(function () {
                     var $input = $(this)
                     if ($input.val()) {
                         $input.removeAttr('value')
                     }
                 });
+                
+                new_form = template_form.clone().removeClass(options.emptyCssClass).addClass("dynamic-" + formset_prefix);
+                new_form.insertBefore(template_form);
 
                 // Update Form Properties
                 update_props(template, normalized_formset_prefix, formset_prefix);


### PR DESCRIPTION
We deleted "value" in all inputs in new form, but stay it in "empty-form", so if add next form is possible to have "id" value from form before cloned. So, we have new not-saved formset and inlines with id to other formset. Which lead to, "The inline foreign key did not match the parent instance primary key" error.