### PR TITLE
Use Django svg-icons instead of gif

### DIFF
--- a/nested_inline/templates/admin/edit_inline/tabular-nested.html
+++ b/nested_inline/templates/admin/edit_inline/tabular-nested.html
@@ -11,7 +11,7 @@
      {% for field in recursive_formset.fields %}
        {% if not field.widget.is_hidden %}
          <th{% if forloop.first %} colspan="2"{% endif %}{% if field.required %} class="required"{% endif %}>{{ field.label|capfirst }}
-         {% if field.help_text %}&nbsp;<img src="{% static "admin/img/icon-unknown.gif" %}" class="help help-tooltip" width="10" height="10" alt="({{ field.help_text|striptags }})" title="{{ field.help_text|striptags }}" />{% endif %}
+         {% if field.help_text %}&nbsp;<img src="{% static "admin/img/icon-unknown.svg" %}" class="help help-tooltip" width="10" height="10" alt="({{ field.help_text|striptags }})" title="{{ field.help_text|striptags }}" />{% endif %}
          </th>
        {% endif %}
      {% endfor %}


### PR DESCRIPTION
The admin icons were changed from .gif to .svg in Django 1.9:

* https://docs.djangoproject.com/en/stable/releases/1.9/#new-styling-for-contrib-admin
* https://github.com/django/django/commit/c32b61c6fd6ddf39fd49585954d422ef8d7304f6#diff-2949e497e8480d99bb7e46adaf8b3f91
* https://github.com/django/django/commit/86cd89095a9e92074d7eb93f2786e765ccb843e4#diff-2949e497e8480d99bb7e46adaf8b3f91