### PR TITLE
catch up Django renaming Model._meta.module_name to model_name

### DIFF
--- a/nested_inline/admin.py
+++ b/nested_inline/admin.py
@@ -266,7 +266,7 @@ class NestedModelAdmin(admin.ModelAdmin):
 
         if request.method == 'POST' and "_saveasnew" in request.POST:
             return self.add_view(request, form_url=reverse('admin:%s_%s_add' %
-                                                           (opts.app_label, opts.module_name),
+                                                           (opts.app_label, opts.model_name),
                 current_app=self.admin_site.name))
 
         ModelForm = self.get_form(request, obj)


### PR DESCRIPTION
This is the change talked in https://github.com/s-block/django-nested-inline/issues/14
Please make a Pypi release if possible. Thanks!