### PR TITLE
Add support for Django 3.0

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -50,11 +50,15 @@ jobs:
           - "py36-django20"
           - "py36-django21"
           - "py36-django22"
+          - "py36-django30"
 
           - "py37-django11"
           - "py37-django20"
           - "py37-django21"
           - "py37-django22"
+          - "py37-django30"
+
+          - "py38-django30"
 
         include:
           - python: "2.7"
@@ -77,6 +81,8 @@ jobs:
             tox_env: "py36-django21"
           - python: "3.6"
             tox_env: "py36-django22"
+          - python: "3.6"
+            tox_env: "py36-django30"
 
           - python: "3.7"
             tox_env: "py37-django11"
@@ -86,6 +92,11 @@ jobs:
             tox_env: "py37-django21"
           - python: "3.7"
             tox_env: "py37-django22"
+          - python: "3.7"
+            tox_env: "py37-django30"
+
+          - python: "3.8"
+            tox_env: "py38-django30"
 
 
     steps:

--- a/nested_inline/admin.py
+++ b/nested_inline/admin.py
@@ -3,12 +3,12 @@ from django.conf import settings
 from django.contrib import admin
 from django.contrib.admin import helpers
 from django.contrib.admin.options import InlineModelAdmin, reverse
-from django.contrib.admin.templatetags.admin_static import static
 from django.contrib.admin.utils import unquote
 from django.core.exceptions import PermissionDenied
 from django.db import models, transaction
 from django.forms.formsets import all_valid
 from django.http import Http404
+from django.templatetags.static import static
 from django.utils.decorators import method_decorator
 from django.utils.encoding import force_text
 from django.utils.html import escape

--- a/nested_inline/templates/admin/edit_inline/stacked-nested.html
+++ b/nested_inline/templates/admin/edit_inline/stacked-nested.html
@@ -1,4 +1,4 @@
-{% load i18n admin_static %}
+{% load i18n static %}
 <div class="inline-group{% if recursive_formset %} {{ recursive_formset.formset.prefix|default:"Root" }}-nested-inline {% if prev_prefix %} {{ prev_prefix }}-{{ loopCounter }}-nested-inline{% endif %} nested-inline{% endif %}" id="{{ inline_admin_formset.formset.prefix }}-group">
 {% with recursive_formset=inline_admin_formset stacked_template='admin/edit_inline/stacked-nested.html' tabular_template='admin/edit_inline/tabular-nested.html'%}
   <h2>{{ recursive_formset.opts.verbose_name_plural|title }}</h2>

--- a/nested_inline/templates/admin/edit_inline/tabular-nested.html
+++ b/nested_inline/templates/admin/edit_inline/tabular-nested.html
@@ -1,4 +1,4 @@
-{% load i18n admin_static admin_modify %}
+{% load i18n static admin_modify %}
 <div class="inline-group{% if recursive_formset %} {{ recursive_formset.formset.prefix|default:"Root" }}-nested-inline{% if prev_prefix %} {{ prev_prefix }}-{{ loopCounter }}-nested-inline{% endif %} nested-inline{% endif %}" id="{{ inline_admin_formset.formset.prefix }}-group">
 {% with recursive_formset=inline_admin_formset stacked_template='admin/edit_inline/stacked-nested.html' tabular_template='admin/edit_inline/tabular-nested.html'%}
   <div class="tabular inline-related {% if forloop.last %}last-related{% endif %}" id="{{ recursive_formset.formset.prefix }}">

--- a/tox.ini
+++ b/tox.ini
@@ -4,6 +4,7 @@ envlist =
     {py35,py36,py37}-django20,
     {py35,py36,py37}-django21,
     {py35,py36,py37}-django22,
+    {py36,py37,py38}-django30,
 
 [testenv]
 commands =
@@ -14,3 +15,4 @@ deps =
     django20: django==2.0.*
     django21: django==2.1.*
     django22: django==2.2.*
+    django30: django>=3.0a1,<3.1


### PR DESCRIPTION
`admin_static` was [deprecated](https://docs.djangoproject.com/en/dev/releases/2.1/#features-deprecated-in-2-1) in Django 2.1 and will be [removed](https://docs.djangoproject.com/en/dev/releases/3.0/#features-removed-in-3-0) in 3.0