### PR TITLE
Update .field-box => .fieldBox

### DIFF
--- a/nested_inline/static/admin/css/forms-nested.css
+++ b/nested_inline/static/admin/css/forms-nested.css
@@ -106,7 +106,7 @@ form .aligned p.help {
     padding-left: 0 !important;
 }
 
-fieldset .field-box {
+fieldset .fieldBox {
     float: left;
     margin-right: 20px;
 }


### PR DESCRIPTION
> The admin CSS class field-box is renamed to fieldBox to prevent conflicts with the class given to model fields named “box”.

https://docs.djangoproject.com/en/3.0/releases/2.1/#miscellaneous