### PR TITLE
Add .fieldBox styling for django 2.1+

### DIFF
--- a/nested_inline/static/admin/css/forms-nested.css
+++ b/nested_inline/static/admin/css/forms-nested.css
@@ -106,7 +106,7 @@ form .aligned p.help {
     padding-left: 0 !important;
 }
 
-fieldset .field-box {
+fieldset .field-box, fieldset .fieldBox {
     float: left;
     margin-right: 20px;
 }


### PR DESCRIPTION
The `field-box` class has been renamed to `fieldBox` in django 2.1, therefore the style doesn't work from django 2.1 onwards. This PR adds `fieldset .fieldBox` to the style, to bring compatibility with django 2.1+

Reference:
> The admin CSS class field-box is renamed to fieldBox to prevent conflicts with the class given to model fields named “box”.

https://docs.djangoproject.com/en/3.0/releases/2.1/#miscellaneous