### PR TITLE
Fix properties breaking admin alignment in Django3

### DIFF
--- a/nested_inline/admin.py
+++ b/nested_inline/admin.py
@@ -8,7 +8,6 @@ from django.core.exceptions import PermissionDenied
 from django.db import models, transaction
 from django.forms.formsets import all_valid
 from django.http import Http404
-from django.templatetags.static import static
 from django.utils.decorators import method_decorator
 from django.utils.encoding import force_text
 from django.utils.html import escape
@@ -390,7 +389,7 @@ class NestedInline(InlineInstancesMixin, InlineModelAdmin):
             js.extend(['urlify.js', 'prepopulate%s.js' % extra])
         if self.filter_vertical or self.filter_horizontal:
             js.extend(['SelectBox.js', 'SelectFilter2.js'])
-        return forms.Media(js=[static('admin/js/%s' % url) for url in js])
+        return forms.Media(js=['admin/js/%s' % url for url in js])
 
     def get_formsets_with_inlines(self, request, obj=None):
         for inline in self.get_inline_instances(request):

--- a/nested_inline/static/admin/css/forms-nested.css
+++ b/nested_inline/static/admin/css/forms-nested.css
@@ -64,7 +64,6 @@ form ul.inline li {
     display: block;
     padding: 3px 10px 0 0;
     float: left;
-    width: 8em;
 }
 
 .aligned ul label {
@@ -75,11 +74,6 @@ form ul.inline li {
 
 .colMS .aligned .vLargeTextField, .colMS .aligned .vXMLLargeTextField {
     width: 350px;
-}
-
-form .aligned p, form .aligned ul {
-    margin-left: 7em;
-    padding-left: 30px;
 }
 
 form .aligned table p {
@@ -160,7 +154,6 @@ fieldset.monospace textarea {
     padding: 5px 7px;
     text-align: right;
     background-color: white;
-    border: 1px solid #ccc;
     margin: 5px 0;
     overflow: hidden;
 }


### PR DESCRIPTION
Django3 somewhat changed it's styling. That resulted in collision with django-nested-inline which was overloading a bunch of variables in Django admin css files. That resulted in an unaligned admin page and other styling errors.