### PR TITLE
Fix FieldDoesNotExist error for Django >= 3.1.2

### DIFF
--- a/nested_inline/admin.py
+++ b/nested_inline/admin.py
@@ -4,7 +4,7 @@ from django.contrib import admin
 from django.contrib.admin import helpers
 from django.contrib.admin.options import InlineModelAdmin, reverse
 from django.contrib.admin.utils import unquote
-from django.core.exceptions import PermissionDenied
+from django.core.exceptions import FieldDoesNotExist, PermissionDenied
 from django.db import models, transaction
 from django.forms.formsets import all_valid
 from django.http import Http404
@@ -215,7 +215,7 @@ class NestedModelAdmin(InlineInstancesMixin, admin.ModelAdmin):
             for k in initial:
                 try:
                     f = opts.get_field(k)
-                except models.FieldDoesNotExist:
+                except FieldDoesNotExist:
                     continue
                 if isinstance(f, models.ManyToManyField):
                     initial[k] = initial[k].split(",")


### PR DESCRIPTION
In Django 3.1.2, the `FieldDoesNotExist` exception is not available in the `django.db.models` namespace, which causes errors to be thrown when adding a related model via the admin site, for example. This simple fix resolves that issue.