### PR TITLE
Fix select2 import for Django >=2.2

### DIFF
--- a/example/app/admin.py
+++ b/example/app/admin.py
@@ -1,7 +1,12 @@
 from django.contrib import admin
 
-from example.app.models import LevelOne, LevelThree, LevelTwo, TopLevel
+from example.app.models import Foo, LevelOne, LevelThree, LevelTwo, TopLevel
 from nested_inline.admin import NestedModelAdmin, NestedStackedInline
+
+
+class FooAdmin(admin.ModelAdmin):
+    model = Foo
+    search_fields = ['name']
 
 
 class LevelThreeInline(NestedStackedInline):
@@ -27,6 +32,8 @@ class LevelOneInline(NestedStackedInline):
 class TopLevelAdmin(NestedModelAdmin):
     model = TopLevel
     inlines = [LevelOneInline]
+    autocomplete_fields = ['foos']
 
 
+admin.site.register(Foo, FooAdmin)
 admin.site.register(TopLevel, TopLevelAdmin)

--- a/example/app/models.py
+++ b/example/app/models.py
@@ -1,8 +1,13 @@
 from django.db import models
 
 
+class Foo(models.Model):
+    name = models.CharField(max_length=200)
+
+
 class TopLevel(models.Model):
     name = models.CharField(max_length=200)
+    foos = models.ManyToManyField('Foo')
 
 
 class LevelOne(models.Model):

--- a/nested_inline/admin.py
+++ b/nested_inline/admin.py
@@ -383,10 +383,25 @@ class NestedInline(InlineInstancesMixin, InlineModelAdmin):
     @property
     def media(self):
         extra = '' if settings.DEBUG else '.min'
-        if VERSION[:2] >= (1, 9):
-            js = ['vendor/jquery/jquery%s.js' % extra, 'jquery.init.js']
+        if VERSION[:2] >= (2, 2):
+            js = [
+                'vendor/select2/select2.full.js',
+                'vendor/jquery/jquery%s.js' % extra,
+            ]
+        elif VERSION[:2] >= (2, 0):
+            js = [
+                'vendor/jquery/jquery%s.js' % extra,
+                'vendor/select2/select2.full.js',
+            ]
+        elif VERSION[:2] >= (1, 9):
+            js = [
+                'vendor/jquery/jquery%s.js' % extra,
+            ]
         else:
-            js = ['jquery%s.js' % extra, 'jquery.init.js']
+            js = [
+                'jquery%s.js' % extra,
+            ]
+        js.append('jquery.init.js')
         js.append('inlines-nested%s.js' % extra)
         if self.prepopulated_fields:
             js.extend(['urlify.js', 'prepopulate%s.js' % extra])


### PR DESCRIPTION
Fixes #129

Note that while this updates the example app it does not alter any of the tests. The updates are currently only for manual testing.