### PR TITLE
Use `ModelAdmin.get_inlines()`

### DIFF
--- a/nested_inline/admin.py
+++ b/nested_inline/admin.py
@@ -21,7 +21,7 @@ csrf_protect_m = method_decorator(csrf_protect)
 class InlineInstancesMixin():
     def get_inline_instances(self, request, obj=None):
         inline_instances = []
-        for inline_class in self.inlines:
+        for inline_class in self.get_inlines(request, obj):
             inline = inline_class(self.model, self.admin_site)
             if request:
                 if VERSION < (2, 1, 0):


### PR DESCRIPTION
ModelAdmin uses a get function to allow overriding `self.inlines`. NestedModelAdmin ignores this override by accessing `self.inlines` directly. This PR fixes that.